### PR TITLE
fix(audit): use consistent pragma across source files

### DIFF
--- a/src/KeyLib.sol
+++ b/src/KeyLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.30;
 
 import {IERC1271} from './interfaces/IERC1271.sol';
 import {ECDSA} from 'lib/solady/src/utils/ECDSA.sol';

--- a/src/KeyManagerEmissary.sol
+++ b/src/KeyManagerEmissary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.30;
 
 import {DynamicArrayLib} from 'lib/solady/src/utils/DynamicArrayLib.sol';
 import {IEmissary} from 'lib/the-compact/src/interfaces/IEmissary.sol';


### PR DESCRIPTION
## Summary
Modifies the pragma directives for `KeyLib.sol` and `KeyManagerEmissary.sol` to match other source files.

## Changes
- Changed pragma directive in `KeyLib.sol` and `KeyManagerEmissary.sol` to `^0.8.30`