### PR TITLE
fix(audit): unify key management auth validation for multisig flows

### DIFF
--- a/src/GenericKeyManager.sol
+++ b/src/GenericKeyManager.sol
@@ -527,7 +527,6 @@ contract GenericKeyManager {
         uint16[] calldata signerIndices,
         ResetPeriod resetPeriod
     ) external returns (bytes32 multisigHash) {
-        _checkKeyManagementAuthorization(account);
         return _registerMultisig(account, threshold, signerIndices, resetPeriod);
     }
 
@@ -559,6 +558,8 @@ contract GenericKeyManager {
         uint16[] calldata signerIndices,
         ResetPeriod resetPeriod
     ) internal returns (bytes32 multisigHash) {
+        _checkKeyManagementAuthorization(account);
+
         // Validate inputs
         uint8 signerCount = uint8(signerIndices.length);
         require(threshold > 0 && threshold <= signerCount, InvalidMultisigConfig('Invalid threshold'));


### PR DESCRIPTION
## Summary
Ensures both external multisig registration paths enforce the same authorization by moving `_checkKeyManagementAuthorization(account)` into the internal `_registerMultisig`. This resolves [OZ Audit Issue L-03](https://defender.openzeppelin.com/#/audit/69aa9ad9-c370-4f29-a9e9-f3dc69e2d43c/issues/L-03).

## Changes
- `src/GenericKeyManager.sol`:
  - `_registerMultisig(...)` now calls `_checkKeyManagementAuthorization(account)` before validation and state changes. Removed redundant auth check from `registerMultisig(account, ...)` entrypoint.